### PR TITLE
Creating new ShipStation orders requires array input.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ An example on how to create a new order to be shipped:
     $order->shipTo = $address;
     $order->items[] = $item;
 
-    // This will var_dump the newly created order.
-    var_dump($shipStation->orders->post($order, 'createorder'));
-    // or with the helper: $shipStation->orders->create($order); would be the same.
+    // This will var_dump the newly created order, and order should be wrapped in an array.
+    var_dump($shipStation->orders->post([$order], 'createorder'));
+    // or with the helper: $shipStation->orders->create([$order]); would be the same.
 ```
 ### DELETE
 ```php


### PR DESCRIPTION
This only worked for me after wrapping the `$order` in an array. Prior to doing this, ShipStation error messages as follows:

```
{
  "Message": "The request is invalid.",
  "ModelState": {
    "apiOrders.orderNumber": [
      "Cannot deserialize the current JSON object (e.g. {\"name\":\"value\"}) into type 'SS.OpenApi.Models.Orders.Order[]' because the type requires a JSON array (e.g. [1,2,3]) to deserialize correctly.\r\nTo fix this error either change the JSON to a JSON array (e.g. [1,2,3]) or change the deserialized type so that it is a normal .NET type (e.g. not a primitive type like integer, not a collection type like an array or List<T>) that can be deserialized from a JSON object. JsonObjectAttribute can also be added to the type to force it to deserialize from a JSON object.\r\nPath 'orderNumber', line 1, position 15."
    ]
  }
}
```