### PR TITLE
Default null raises exception. Default modal to ShipStation boolean d…

### DIFF
--- a/src/Models/AdvancedOptions.php
+++ b/src/Models/AdvancedOptions.php
@@ -14,17 +14,17 @@ class AdvancedOptions
     /**
      * @var bool Specifies whether the order is non-machinable.
      */
-    public $nonMachinable;
+    public $nonMachinable = false;
 
     /**
      * @var bool Specifies whether the order is to be delivered on a Saturday.
      */
-    public $saturdayDelivery;
+    public $saturdayDelivery = false;
 
     /**
      * @var bool Specifies whether the order contains alcohol.
      */
-    public $containsAlcohol;
+    public $containsAlcohol = false;
 
     /**
      * @var int ID of store that is associated with the order. If not specified in


### PR DESCRIPTION
…efaults.

Unless you explicitly set all the `boolean` properties, `null` throws the following api error:

```
{
  "Message": "The request is invalid.",
  "ModelState": {
    "apiOrders[0].advancedOptions.nonMachinable": [
      "Error converting value {null} to type 'System.Boolean'. Path '[0].advancedOptions.nonMachinable', line 1, position 1533."
    ]
  }
}
```