### PR TITLE
Fixed a 'Division by Zero' error in the sleepIfRateLimited() method.

### DIFF
--- a/src/ShipStation.php
+++ b/src/ShipStation.php
@@ -127,7 +127,7 @@ class ShipStation extends Client
         $rateLimit = $response->getHeader('X-Rate-Limit-Remaining')[0];
         $rateLimitWait = $response->getHeader('X-Rate-Limit-Reset')[0];
 
-        if (($rateLimitWait / $rateLimit) > 1.5) {
+        if ($rateLimit > 0 && ($rateLimitWait / $rateLimit) > 1.5) {
             sleep(1.5);
         }
     }

--- a/src/ShipStation.php
+++ b/src/ShipStation.php
@@ -127,7 +127,7 @@ class ShipStation extends Client
         $rateLimit = $response->getHeader('X-Rate-Limit-Remaining')[0];
         $rateLimitWait = $response->getHeader('X-Rate-Limit-Reset')[0];
 
-        if ($rateLimit > 0 && ($rateLimitWait / $rateLimit) > 1.5) {
+        if ($rateLimit === 0 || ($rateLimitWait / $rateLimit) > 1.5) {
             sleep(1.5);
         }
     }


### PR DESCRIPTION
Occasionally I am getting a "Division by Zero" error when the "X-Rate-Limit-Remaining" header is set and equals 0.

I added a quick check to make sure that it's greater than 0 before it does the division.