### PR TITLE
Feature/add partner key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ After installing via composer you will need to publish the configuration:
 php artisan vendor:publish
 ```
 This will create the configuration file for your API key and API secret key at ```config/shipstation.php```. You will need to obtain your API & Secret key from ShipStation: [How can I get access to ShipStation's API?](https://help.shipstation.com/hc/en-us/articles/206638917-How-can-I-get-access-to-ShipStation-s-API-)
+
+If ShipStation has provided you with a partner API key, set it in your configuration file.
 ## Dependencies
 LaravelShipStation uses ```GuzzleHttp\Guzzle```
 ## Endpoints

--- a/config/config.php
+++ b/config/config.php
@@ -1,7 +1,8 @@
 <?php
 
 return [
-    'apiURL'    => env('SS_URL', 'https://ssapi.shipstation.com'),
-    'apiKey'    => env('SS_KEY', ''),
-    'apiSecret' => env('SS_SECRET', ''),
+    'apiURL'        => env('SS_URL', 'https://ssapi.shipstation.com'),
+    'apiKey'        => env('SS_KEY', ''),
+    'partnerApiKey' => env('SS_PARTNER_KEY', ''),
+    'apiSecret'     => env('SS_SECRET', ''),
 ];

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
     <php>
         <env name="SHIPSTATION_TESTING" value="false"/>
         <env name="KEY" value=""/>
+        <env name="PARTNER_KEY" value=""/>
         <env name="SECRET" value=""/>
         <env name="API_URL" value=""/>
     </php>

--- a/src/ShipStation.php
+++ b/src/ShipStation.php
@@ -47,9 +47,11 @@ class ShipStation extends Client
      *
      * @param  string  $apiKey
      * @param  string  $apiSecret
+     * @param  string  $apiURL
+     * @param  string|null  $partnerApiKey
      * @throws \Exception
      */
-    public function __construct($apiKey, $apiSecret, $apiURL)
+    public function __construct($apiKey, $apiSecret, $apiURL, $partnerApiKey = null)
     {
         if (!isset($apiKey, $apiSecret)) {
             throw new \Exception('Your API key and/or private key are not set. Did you run artisan vendor:publish?');
@@ -57,11 +59,17 @@ class ShipStation extends Client
 
         $this->base_uri = $apiURL;
 
+        $headers = [
+            'Authorization' => 'Basic ' . base64_encode("{$apiKey}:{$apiSecret}"),
+        ];
+
+        if (! empty($partnerApiKey)) {
+            $headers['x-partner'] = $partnerApiKey;
+        }
+
         parent::__construct([
             'base_uri' => $this->base_uri,
-            'headers'  => [
-                'Authorization' => 'Basic ' . base64_encode("{$apiKey}:{$apiSecret}"),
-            ]
+            'headers'  => $headers,
         ]);
     }
 

--- a/src/ShipStationServiceProvider.php
+++ b/src/ShipStationServiceProvider.php
@@ -29,7 +29,8 @@ class ShipStationServiceProvider extends ServiceProvider
             return new ShipStation(
                 config('shipstation.apiKey'),
                 config('shipstation.apiSecret'),
-                config('shipstation.apiURL')
+                config('shipstation.apiURL'),
+                config('shipstation.partnerApiKey')
             );
         });
     }

--- a/tests/ShipStationTest.php
+++ b/tests/ShipStationTest.php
@@ -22,7 +22,12 @@ class ShipStationTest extends PHPUnit_Framework_TestCase
             exit();
         }
 
-        $this->shipStation = new LaravelShipStation\ShipStation(getenv('KEY'), getenv('SECRET'), getenv('API_URL'));
+        $this->shipStation = new LaravelShipStation\ShipStation(
+            getenv('KEY'),
+            getenv('SECRET'),
+            getenv('API_URL'),
+            getenv('PARTNER_KEY')
+        );
     }
 
     /** @test */
@@ -125,5 +130,20 @@ class ShipStationTest extends PHPUnit_Framework_TestCase
         $this->assertGreaterThanOrEqual(0, $this->shipStation->getRemainingRequests());
         $this->assertGreaterThanOrEqual(0, $this->shipStation->getSecondsUntilReset());
         $this->assertInternalType('boolean', $this->shipStation->isRateLimited());
+    }
+
+    /** @test */
+    public function partner_api_key_header_is_set_when_defined()
+    {
+        if (empty(getenv('PARTNER_KEY'))) {
+            // nothing to test
+            return;
+        }
+
+        $this->shipStation->webhooks->get();
+
+        $headers = $this->shipStation->request->getConfig('headers');
+
+        $this->assertArrayHasKey('x-partner', $headers);
     }
 }


### PR DESCRIPTION
ShipStation has an enterprise-level tier/option that increases the allowed API calls per minute. This PR adds support for the required partner key and `x-partner` header.

For reference, this is their email with instructions on how to send the key:

![image](https://user-images.githubusercontent.com/748444/82376882-07c07980-99e0-11ea-8301-9ff0b52bc037.png)

And this is the result of providing a valid partner key:

```
[
  "maxAllowedRequests" => 100
  "remainingRequests" => 97
  "secondsUntilReset" => 59
  "isRateLimited" => false
]
```

Hopefully I can stop fighting the constant rate limit errors now! 🙌 