### PR TITLE
Add support for Laravel's Package Discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,13 @@
             "LaravelShipStation\\": "src/"
         }
     },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "LaravelShipStation\\ShipStationServiceProvider"
+            ]
+        }
+    },
     "require": {
         "guzzlehttp/guzzle": "^6.3|^7.0.1"
     },


### PR DESCRIPTION
On Laravel 5.5 and up this means we can skip manually registering the service provider inside of `config/app.php`.

Docs: https://laravel.com/docs/8.x/packages#package-discovery