### PR TITLE
Add missing property under AdvancedOptions Model

### DIFF
--- a/src/Models/AdvancedOptions.php
+++ b/src/Models/AdvancedOptions.php
@@ -72,4 +72,9 @@ class AdvancedOptions
      * @var string Country Code of billToParty.
      */
     public $billToCountryCode;
+
+    /**
+     * @var string When using my_other_account as the billToParty value, the shippingProviderId value that is associated with the desired account.
+     */
+    public $billToMyOtherAccount;
 }


### PR DESCRIPTION
## Summary

Adds support for the `billToMyOtherAccount` property to the `AdvancedOptions` model, aligning the package with ShipStation’s official API documentation.

## Background

According to ShipStation’s API reference, the `billToMyOtherAccount` field allows designating that shipping costs should be billed to a different ShipStation carrier account. This property was not previously defined in the `AdvancedOptions` model, which could result in incomplete payloads for users leveraging this feature.

## Changes

- Added the `billToMyOtherAccount` property to the `AdvancedOptions` model.
- Verified naming and type against ShipStation’s latest API specification.

## Testing

- Confirmed that requests now include the `billToMyOtherAccount` value when provided.
- Ensured no breaking changes to existing advanced option handling.

## References

ShipStation API Documentation: https://www.shipstation.com/docs/api/orders/create-update/